### PR TITLE
Support float8 kv-cache for R1

### DIFF
--- a/vllm/attention/ops/flashmla.py
+++ b/vllm/attention/ops/flashmla.py
@@ -46,9 +46,8 @@ def get_mla_metadata(
         num_heads_per_head_k: Equals to seq_len_q * num_heads_q // num_heads_k.
         num_heads_k: num_heads_k.
 
-    Return:
-        tile_scheduler_metadata: (num_sm_parts, TileSchedulerMetaDataSize), 
-                                 dtype torch.int32.
+    Returns:
+        tile_scheduler_metadata: (num_sm_parts, TileSchedulerMetaDataSize), dtype torch.int32.
         num_splits: (batch_size + 1), dtype torch.int32.
     """
     return torch.ops._flashmla_C.get_mla_metadata(cache_seqlens,
@@ -66,6 +65,8 @@ def flash_mla_with_kvcache(
     num_splits: torch.Tensor,
     softmax_scale: Optional[float] = None,
     causal: bool = False,
+    descale_q: Optional[torch.Tensor] = None,
+    descale_k: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Arguments:
@@ -73,14 +74,14 @@ def flash_mla_with_kvcache(
         k_cache: (num_blocks, page_block_size, num_heads_k, head_dim).
         block_table: (batch_size, max_num_blocks_per_seq), torch.int32.
         cache_seqlens: (batch_size), torch.int32.
-        head_dim_v: Head_dim of v.
-        tile_scheduler_metadata: (num_sm_parts, TileSchedulerMetaDataSize), 
-                                 torch.int32, return by get_mla_metadata.
-        num_splits: (batch_size + 1), torch.int32, return by get_mla_metadata.
-        softmax_scale: float. The scaling of QK^T before applying softmax. 
-                       Default to 1 / sqrt(head_dim).
+        head_dim_v: Head dimension of v.
+        tile_scheduler_metadata: (num_sm_parts, TileSchedulerMetaDataSize), torch.int32, returned by get_mla_metadata.
+        num_splits: (batch_size + 1), torch.int32, returned by get_mla_metadata.
+        softmax_scale: float. The scale of QK^T before applying softmax. Default to 1 / sqrt(head_dim).
         causal: bool. Whether to apply causal attention mask.
-
+        descale_q: (batch_size), torch.float. dequant scale for query
+        descale_k: (batch_size), torch.float. dequant scale for key
+        
     Return:
         out: (batch_size, seq_len_q, num_heads_q, head_dim_v).
         softmax_lse: (batch_size, num_heads_q, seq_len_q), torch.float32.
@@ -98,9 +99,9 @@ def flash_mla_with_kvcache(
         causal,
         tile_scheduler_metadata,
         num_splits,
+        descale_q, descale_k,
     )
     return out, softmax_lse
-
 
 #
 # TODO: Add fake functions


### PR DESCRIPTION
```
| 卡型 | 推理引擎 | Model | optimize | TP | DType | Model Length | Input/Output Length | QPS | max_concurrency | Throughput(req/s) | Throughput(token/s) - input+ouput | Throughput(token/s) - input | Throughput(token/s) - output | Total token throughput (tok/s/单卡) | TTFT(P50, ms) | TTFT(P95, ms) | TTFT(avg, ms) | TPOT(p50, ms) | TPOT(P95, ms) | TPOT(avg, ms) |
|------|----------|--------|-----------|----|---------|--------------|--------------------|-----|-----------------|-------------------|-----------------------------------|----------------------------|-----------------------------|------------------------------------|---------------|---------------|---------------|---------------|---------------|---------------|
| H20 | vllm 0.7.4 | R1-w4a16 | NCCL,cuda-graph,kv-fp8 | 8 | w4a16+kv fp8 | 131072 | 3500/1500 | 4 | 11 | 0.12 | 612.05 | 428.43 | 183.61 | 76.51 | 5985.12 | 6356.21 | 5018.64 | 53.72 | 57.29 | 51.90 |
| H20 | vllm 0.7.4 | R1-w4a16 | NCCL,cuda-graph,kv-fp8 | 8 | w4a16 | 131072 | 3500/1500 | 8 | | 0.12 | 580.44 | | | 72.56 | 5149.32 | 5256.10 | 4999.41 | 34.30 | 35.32 | 34.50 |
```