### PR TITLE
feat(kv_transfer): 添加kv_use_eic配置以支持预填充实例的kv缓存重用

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3265,6 +3265,9 @@ class KVTransferConfig(BaseModel):
     # The KV connector port, used to build distributed connection
     kv_port: int = 14579
 
+    # Whether use eic for kv cache reuse for prefill instance
+    kv_use_eic: bool = False
+
     # any extra config that the connector may need
     kv_connector_extra_config: dict[str, Any] = {}
 

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -40,6 +40,10 @@ class KVConnectorFactory:
             raise ValueError("Attempting to initialize a V0 Connector, "
                              f"but found {envs.VLLM_USE_V1=}")
 
+        if (config.kv_transfer_config.kv_connector == "DynamoNixlConnector"
+                    and config.kv_transfer_config.kv_use_eic):
+            from vllm.distributed.kv_transfer.kv_connector.lmcache_connector import LMCacheConnector
+            return LMCacheConnector(rank, local_rank, config)
         connector_name = config.kv_transfer_config.kv_connector
         if connector_name not in cls._registry:
             raise ValueError(f"Unsupported connector type: {connector_name}")

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1884,7 +1884,8 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         if self.vllm_config.kv_transfer_config is None:
             return False
 
-        if self.vllm_config.kv_transfer_config.kv_connector == "DynamoNixlConnector":
+        if self.vllm_config.kv_transfer_config.kv_connector == "DynamoNixlConnector" and \
+            not self.vllm_config.kv_transfer_config.kv_use_eic:
             return False
 
         prefill_meta = model_input.attn_metadata.prefill_metadata
@@ -1922,7 +1923,8 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         if self.vllm_config.kv_transfer_config is None:
             return False
 
-        if self.vllm_config.kv_transfer_config.kv_connector == "DynamoNixlConnector":
+        if (self.vllm_config.kv_transfer_config.kv_connector == "DynamoNixlConnector"
+                and not self.vllm_config.kv_transfer_config.kv_use_eic):
             return False
 
         prefill_meta = model_input.attn_metadata.prefill_metadata


### PR DESCRIPTION


<!--- pyml disable-next-line no-emphasis-as-heading -->
